### PR TITLE
Automatic section numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ public
 .env
 resources
 .idea/
+.hugo_build.lock

--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -78,6 +78,8 @@ enabledModule = "base"
 # Enable Lunr.js offline search
 offlineSearch = true
 
+automaticSectionNumbers = true
+
 [params.ui]
 # Enable to show the side bar menu in its compact state.
 sidebar_menu_compact = false

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -1,9 +1,8 @@
 ---
-title: "Labs"
+title: Labs
 weight: 2
 menu:
   main:
-    weight: 2
 ---
 
 ## Lab Introduction

--- a/content/en/docs/getting-started.md
+++ b/content/en/docs/getting-started.md
@@ -3,9 +3,11 @@ title: Getting Started
 weight: 20
 ---
 
+
 ## {{%task%}} Getting Started
 
 aieaiea
+
 
 ## {{%task%}} Getting Started
 

--- a/content/en/docs/getting-started.md
+++ b/content/en/docs/getting-started.md
@@ -5,4 +5,8 @@ weight: 20
 
 ## {{%task%}} Getting Started
 
+aieaiea
+
 ## {{%task%}} Getting Started
+
+aiea

--- a/content/en/docs/getting-started.md
+++ b/content/en/docs/getting-started.md
@@ -1,0 +1,8 @@
+---
+title: Getting Started
+weight: 20
+---
+
+## {{%task%}} Getting Started
+
+## {{%task%}} Getting Started

--- a/content/en/docs/introduction.md
+++ b/content/en/docs/introduction.md
@@ -1,0 +1,87 @@
+---
+title: "Introduction"
+weight: 10
+---
+
+## Title 1
+
+{{% alert title="Note" color="primary" %}}
+Sample Note
+{{% /alert %}}
+
+Sample code block:
+```bash
+echo "Hello World!"
+```
+
+{{% onlyWhen variant1 %}}
+This is only rendered when `enabledModule` in `config.toml` contains `variant1`.
+{{% /onlyWhen %}}
+
+{{% onlyWhen variant2 %}}
+This is only rendered when `enabledModule` in `config.toml` contains `variant2`.
+{{% /onlyWhen %}}
+
+{{% onlyWhen variant1 variant2 %}}
+This is only rendered when `enabledModule` in `config.toml` contains `variant1` or `variant2`.
+{{% /onlyWhen %}}
+
+{{% onlyWhen variant9 %}}
+This is only rendered when `enabledModule` in `config.toml` contains `variant9`.
+{{% /onlyWhen %}}
+
+{{% onlyWhenNot variant1 %}}
+This is only rendered when `enabledModule` in `config.toml` **does not** contain `variant1`.
+{{% /onlyWhen %}}
+
+{{% onlyWhenNot variant2 %}}
+This is only rendered when `enabledModule` in `config.toml` **does not** contain `variant2`.
+{{% /onlyWhen %}}
+
+{{% onlyWhenNot variant1 variant2 %}}
+This is only rendered when `enabledModule` in `config.toml` **does not** contain `variant1` **nor** `variant2`.
+{{% /onlyWhen %}}
+
+{{% onlyWhenNot variant9 %}}
+This is only rendered when `enabledModule` in `config.toml` **does not** contain `variant9`.
+{{% /onlyWhen %}}
+
+
+## Title 2
+
+
+```yaml
+foo: bar
+```
+
+
+## {{%task%}} Fix Deployment
+
+
+```yaml
+foo: bar
+```
+
+
+## {{%task%}} Fix Release
+
+
+```yaml
+foo: bar
+```
+
+
+## {{%task%}} Fix Release again
+
+
+```yaml
+foo: bar
+```
+
+
+## {{%task%}} Fix Release again and again
+
+
+```yaml
+foo: bart
+```

--- a/content/en/docs/testing/_index.md
+++ b/content/en/docs/testing/_index.md
@@ -1,7 +1,6 @@
 ---
-title: "1. Go Basics Sample Chapter"
-weight: 1
-sectionnumber: 1
+title: "Testing"
+weight: 15
 ---
 
 ## Title 1
@@ -56,7 +55,7 @@ foo: bar
 ```
 
 
-## Task 1.1: Fix Deployment
+## {{%task%}} Fix Deployment
 
 
 ```yaml
@@ -64,7 +63,7 @@ foo: bar
 ```
 
 
-## Task 1.2: Fix Release
+## {{%task%}} Fix Release
 
 
 ```yaml
@@ -72,7 +71,7 @@ foo: bar
 ```
 
 
-## Task 1.3: Fix Release again
+## {{%task%}} Fix Release again
 
 
 ```yaml
@@ -80,7 +79,7 @@ foo: bar
 ```
 
 
-## Task 1.4: Fix Release again and again
+## {{%task%}} Fix Release again and again
 
 
 ```yaml

--- a/content/en/docs/testing/tooling.md
+++ b/content/en/docs/testing/tooling.md
@@ -1,0 +1,87 @@
+---
+title: "Tooling"
+weight: 30
+---
+
+## Title 1
+
+{{% alert title="Note" color="primary" %}}
+Sample Note
+{{% /alert %}}
+
+Sample code block:
+```bash
+echo "Hello World!"
+```
+
+{{% onlyWhen variant1 %}}
+This is only rendered when `enabledModule` in `config.toml` contains `variant1`.
+{{% /onlyWhen %}}
+
+{{% onlyWhen variant2 %}}
+This is only rendered when `enabledModule` in `config.toml` contains `variant2`.
+{{% /onlyWhen %}}
+
+{{% onlyWhen variant1 variant2 %}}
+This is only rendered when `enabledModule` in `config.toml` contains `variant1` or `variant2`.
+{{% /onlyWhen %}}
+
+{{% onlyWhen variant9 %}}
+This is only rendered when `enabledModule` in `config.toml` contains `variant9`.
+{{% /onlyWhen %}}
+
+{{% onlyWhenNot variant1 %}}
+This is only rendered when `enabledModule` in `config.toml` **does not** contain `variant1`.
+{{% /onlyWhen %}}
+
+{{% onlyWhenNot variant2 %}}
+This is only rendered when `enabledModule` in `config.toml` **does not** contain `variant2`.
+{{% /onlyWhen %}}
+
+{{% onlyWhenNot variant1 variant2 %}}
+This is only rendered when `enabledModule` in `config.toml` **does not** contain `variant1` **nor** `variant2`.
+{{% /onlyWhen %}}
+
+{{% onlyWhenNot variant9 %}}
+This is only rendered when `enabledModule` in `config.toml` **does not** contain `variant9`.
+{{% /onlyWhen %}}
+
+
+## Title 2
+
+
+```yaml
+foo: bar
+```
+
+
+## {{%task%}} Fix Deployment
+
+
+```yaml
+foo: bar
+```
+
+
+## {{%task%}} Fix Release
+
+
+```yaml
+foo: bar
+```
+
+
+## {{%task%}} Fix Release again
+
+
+```yaml
+foo: bar
+```
+
+
+## {{%task%}} Fix Release again and again
+
+
+```yaml
+foo: bart
+```

--- a/layouts/_default/content.html
+++ b/layouts/_default/content.html
@@ -1,8 +1,8 @@
 {{/* Copied and adapted from themes/docsy/layouts/_default/content.html */}}
 <div class="td-content">
     {{- if site.Params.automaticSectionNumbers -}}
-    {{- $sectionnumbers := partialCached "sectionnumber.html" .Page -}}
-    <h1>{{ $sectionnumbers.Get .Page.File.Path }}. {{ .Title }}</h1>
+    {{- $sectionnumbers := partialCached "sectionnumber.html" . -}}
+    <h1>{{ $sectionnumbers.Get .File.Path }}. {{ .Title }}</h1>
     {{- else -}}
 	<h1>{{ .Title }}</h1>
     {{- end -}}

--- a/layouts/_default/content.html
+++ b/layouts/_default/content.html
@@ -1,8 +1,8 @@
 {{/* Copied and adapted from themes/docsy/layouts/_default/content.html */}}
 <div class="td-content">
     {{- if site.Params.automaticSectionNumbers -}}
-    {{- $data := partialCached "sectionnumber.html" .Page -}}
-    <h1>{{ $data.Get .Page.File.Path }}. {{ .Title }}</h1>
+    {{- $sectionnumbers := partialCached "sectionnumber.html" .Page -}}
+    <h1>{{ $sectionnumbers.Get .Page.File.Path }}. {{ .Title }}</h1>
     {{- else -}}
 	<h1>{{ .Title }}</h1>
     {{- end -}}

--- a/layouts/_default/content.html
+++ b/layouts/_default/content.html
@@ -1,0 +1,36 @@
+{{/* Copied and adapted from themes/docsy/layouts/_default/content.html */}}
+<div class="td-content">
+    {{- if site.Params.automaticSectionNumbers -}}
+    {{- $data := partialCached "sectionnumber.html" .Page -}}
+    <h1>{{ $data.Get .Page.File.Path }}. {{ .Title }}</h1>
+    {{- else -}}
+	<h1>{{ .Title }}</h1>
+    {{- end -}}
+	{{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
+	<header class="article-meta">
+		{{ $context := . }}
+		{{ if .Site.Params.Taxonomy.taxonomyPageHeader }}
+			{{ range $index, $taxo := .Site.Params.Taxonomy.taxonomyPageHeader }}
+				{{ partial "taxonomy_terms_article.html" (dict "context" $context "taxo" $taxo ) }}
+			{{ end }}
+		{{ else }}
+			{{ range $taxo, $taxo_map := .Site.Taxonomies }}
+				{{ partial "taxonomy_terms_article.html" (dict "context" $context "taxo" $taxo ) }}
+			{{ end }}
+		{{ end }}
+		{{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) }}
+			{{ partial "reading-time.html" . }}
+		{{ end }}
+	</header>
+	{{ .Content }}
+    <div class="text-muted mt-5 pt-3">{{ partial "prevnextlinks.html" . }}</div>
+	{{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.GoogleAnalytics)) }}
+		{{ partial "feedback.html" .Site.Params.ui.feedback }}
+		<br />
+	{{ end }}
+	{{ if (.Site.Params.DisqusShortname) }}
+		<br />
+		{{ partial "disqus-comment.html" . }}
+	{{ end }}
+	{{ partial "page-meta-lastmod.html" . }}
+</div>

--- a/layouts/partials/section-index.html
+++ b/layouts/partials/section-index.html
@@ -1,4 +1,5 @@
 {{/* Copied and adapted from themes/docsy/layouts/partials/section-index.html */}}
+{{- $sectionnumbers := partialCached "sectionnumber.html" . -}}
 <div class="section-index">
     {{ $parent := .Page }}
     {{ $pages := (where .Site.Pages "Section" .Section).ByWeight }}
@@ -15,7 +16,11 @@
                 {{ $onlyWhen := default "base" .Params.onlyWhen }}
                 {{ if and (in .Site.Params.enabledModule $onlyWhen) (not (in .Site.Params.enabledModule .Params.onlyWhenNot)) }}
                 {{ $manualLink := cond (isset .Params "manuallink") .Params.manualLink ( cond (isset .Params "manuallinkrelref") (relref . .Params.manualLinkRelref) .RelPermalink) }}
-                <li><a href="{{ $manualLink }}"{{ with .Params.manualLinkTitle }} title="{{ . }}"{{ end }}{{ with .Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }}>{{- .Title -}}</a></li>
+                {{ $title := .Title }}
+                {{ if site.Params.automaticSectionNumbers }}
+                    {{ $title = printf "%s. %s" ($sectionnumbers.Get .File.Path) $title }}
+                {{ end }}
+                <li><a href="{{ $manualLink }}"{{ with .Params.manualLinkTitle }} title="{{ . }}"{{ end }}{{ with .Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }}>{{- $title -}}</a></li>
                 {{ end }}
             {{ end }}
         </ul>
@@ -26,9 +31,13 @@
             {{ $onlyWhen := default "base" .Params.onlyWhen }}
             {{ if and (in .Site.Params.enabledModule $onlyWhen) (not (in .Site.Params.enabledModule .Params.onlyWhenNot)) }}
             {{ $manualLink := cond (isset .Params "manuallink") .Params.manualLink ( cond (isset .Params "manuallinkrelref") (relref . .Params.manualLinkRelref) .RelPermalink) }}
+            {{ $title := .Title }}
+            {{ if site.Params.automaticSectionNumbers }}
+                {{ $title = printf "%s. %s" ($sectionnumbers.Get .File.Path) $title }}
+            {{ end }}
                 <div class="entry">
                     <h5>
-                        <a href="{{ $manualLink }}"{{ with .Params.manualLinkTitle }} title="{{ . }}"{{ end }}{{ with .Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }}>{{- .Title -}}</a>
+                        <a href="{{ $manualLink }}"{{ with .Params.manualLinkTitle }} title="{{ . }}"{{ end }}{{ with .Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }}>{{- $title -}}</a>
                     </h5>
                     <p>{{ .Description | markdownify }}</p>
                 </div>

--- a/layouts/partials/section-index.html
+++ b/layouts/partials/section-index.html
@@ -1,0 +1,39 @@
+{{/* Copied and adapted from themes/docsy/layouts/partials/section-index.html */}}
+<div class="section-index">
+    {{ $parent := .Page }}
+    {{ $pages := (where .Site.Pages "Section" .Section).ByWeight }}
+    {{ $pages = (where $pages "Type" "!=" "search") }}
+    {{ $pages = (where $pages ".Params.hide_summary" "!=" true) }}
+    {{ $pages = (where $pages ".Parent" "!=" nil) }}
+    {{ $pages = (where $pages "Parent.File.UniqueID" "==" $parent.File.UniqueID) }}
+    {{ if or $parent.Params.no_list (eq (len $pages) 0) }}
+    {{/* If no_list is true or we don't have subpages we don't show a list of subpages */}}
+    {{ else if $parent.Params.simple_list }}
+    {{/* If simple_list is true we show a bulleted list of subpages */}}
+        <ul>
+            {{ range $pages }}
+                {{ $onlyWhen := default "base" .Params.onlyWhen }}
+                {{ if and (in .Site.Params.enabledModule $onlyWhen) (not (in .Site.Params.enabledModule .Params.onlyWhenNot)) }}
+                {{ $manualLink := cond (isset .Params "manuallink") .Params.manualLink ( cond (isset .Params "manuallinkrelref") (relref . .Params.manualLinkRelref) .RelPermalink) }}
+                <li><a href="{{ $manualLink }}"{{ with .Params.manualLinkTitle }} title="{{ . }}"{{ end }}{{ with .Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }}>{{- .Title -}}</a></li>
+                {{ end }}
+            {{ end }}
+        </ul>
+    {{ else }}
+    {{/* Otherwise we show a nice formatted list of subpages with page descriptions */}}
+    <hr class="panel-line">
+        {{ range $pages }}
+            {{ $onlyWhen := default "base" .Params.onlyWhen }}
+            {{ if and (in .Site.Params.enabledModule $onlyWhen) (not (in .Site.Params.enabledModule .Params.onlyWhenNot)) }}
+            {{ $manualLink := cond (isset .Params "manuallink") .Params.manualLink ( cond (isset .Params "manuallinkrelref") (relref . .Params.manualLinkRelref) .RelPermalink) }}
+                <div class="entry">
+                    <h5>
+                        <a href="{{ $manualLink }}"{{ with .Params.manualLinkTitle }} title="{{ . }}"{{ end }}{{ with .Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }}>{{- .Title -}}</a>
+                    </h5>
+                    <p>{{ .Description | markdownify }}</p>
+                </div>
+            {{ end }}
+        {{ end }}
+    {{ end }}
+</div>
+<div>{{ partial "prevnextlinks.html" . }}</div>

--- a/layouts/partials/sectionnumber.html
+++ b/layouts/partials/sectionnumber.html
@@ -1,0 +1,31 @@
+{{ $navRoot := cond (and (ne .Params.toc_root true) (eq .Site.Home.Type "docs")) .Site.Home .FirstSection -}}
+{{ $data := newScratch }}
+{{ $data = partial "sectionnumber-nested" (dict "page" . "section" $navRoot "data" $data) }}
+{{ return $data }}
+
+{{ define "partials/sectionnumber-nested" -}}
+{{ $s := .section }}
+{{ $p := .page }}
+{{ $d := .data }}
+{{ $sectionNr := .sectionNr | default "" }}
+{{ $pages := (union .section.Pages $s.Sections).ByWeight -}}
+{{ $withChild := gt (len $pages) 0 -}}
+  {{ $sectionNr }}{{ $s }}
+  {{ .data.Set $s.File.Path $sectionNr }}
+  {{- if $withChild }}
+    {{ range $index, $item := $pages -}}
+      {{ $onlyWhen := default "base" $item.Params.onlyWhen }}
+      {{ if and (in site.Params.enabledModule $onlyWhen) (not (in site.Params.enabledModule $item.Params.onlyWhenNot)) }}
+      {{ if (not (and (eq $s site.Home) (eq $item.Params.toc_root true))) -}}
+        {{ $prefix := $sectionNr }}
+        {{ if $sectionNr }}
+          {{ $prefix = add $sectionNr "." }}
+        {{ end }}
+        {{ $newSectionNr := (add $prefix (string (add $index 1))) }}
+        {{ $d = partial "sectionnumber-nested" (dict "page" $p "section" $item "sectionNr" $newSectionNr "data" $d) }}
+      {{- end }}
+      {{- end }}
+      {{- end }}
+    {{- end }}
+    {{ return $d }}
+{{- end }}

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -1,0 +1,75 @@
+{{/* Copied and adapted from themes/docsy/layouts/partials/sidebar-tree.html */}}
+{{/* We cache this partial for bigger sites and set the active class client side. */}}
+{{ $sidebarCacheLimit := cond (isset .Site.Params.ui "sidebar_cache_limit") .Site.Params.ui.sidebar_cache_limit 2000 -}}
+{{ $shouldDelayActive := ge (len .Site.Pages) $sidebarCacheLimit -}}
+<div id="td-sidebar-menu" class="td-sidebar__inner{{ if $shouldDelayActive }} d-none{{ end }}">
+  {{ if not .Site.Params.ui.sidebar_search_disable -}}
+  <form class="td-sidebar__search d-flex align-items-center">
+    {{ partial "search-input.html" . }}
+    <button class="btn btn-link td-sidebar__toggle d-md-none p-0 ml-3 fas fa-bars" type="button" data-toggle="collapse" data-target="#td-section-nav" aria-controls="td-docs-nav" aria-expanded="false" aria-label="Toggle section navigation">
+    </button>
+  </form>
+  {{ else -}}
+  <div id="content-mobile">
+  <form class="td-sidebar__search d-flex align-items-center">
+    {{ partial "search-input.html" . }}
+    <button class="btn btn-link td-sidebar__toggle d-md-none p-0 ml-3 fas fa-bars" type="button" data-toggle="collapse" data-target="#td-section-nav" aria-controls="td-docs-nav" aria-expanded="false" aria-label="Toggle section navigation">
+    </button>
+  </form>
+  </div>
+  <div id="content-desktop"></div>
+  {{ end -}}
+  <nav class="collapse td-sidebar-nav{{ if .Site.Params.ui.sidebar_menu_foldable }} foldable-nav{{ end }}" id="td-section-nav">
+    {{ if  (gt (len .Site.Home.Translations) 0) -}}
+    <div class="nav-item dropdown d-block d-lg-none">
+      {{ partial "navbar-lang-selector.html" . }}
+    </div>
+    {{ end -}}
+    {{ $navRoot := cond (and (ne .Params.toc_root true) (eq .Site.Home.Type "docs")) .Site.Home .FirstSection -}}
+    {{ $ulNr := 0 -}}
+    {{ $ulShow := cond (isset .Site.Params.ui "ul_show") .Site.Params.ui.ul_show 1 -}}
+    {{ $sidebarMenuTruncate := cond (isset .Site.Params.ui "sidebar_menu_truncate") .Site.Params.ui.sidebar_menu_truncate 50 -}}
+    <ul class="td-sidebar-nav__section pr-md-3 ul-{{ $ulNr }}">
+      {{ template "section-tree-nav-section" (dict "page" . "section" $navRoot "shouldDelayActive" $shouldDelayActive "sidebarMenuTruncate" $sidebarMenuTruncate "ulNr" $ulNr "ulShow" (add $ulShow 1)) }}
+    </ul>
+  </nav>
+</div>
+{{ define "section-tree-nav-section" -}}
+{{ $s := .section -}}
+{{ $p := .page -}}
+{{ $shouldDelayActive := .shouldDelayActive -}}
+{{ $sidebarMenuTruncate := .sidebarMenuTruncate -}}
+{{ $treeRoot := cond (eq .ulNr 0) true false -}}
+{{ $ulNr := .ulNr -}}
+{{ $ulShow := .ulShow -}}
+{{ $active := and (not $shouldDelayActive) (eq $s $p) -}}
+{{ $activePath := and (not $shouldDelayActive) ($p.IsDescendant $s) -}}
+{{ $show := cond (or (lt $ulNr $ulShow) $activePath (and (not $shouldDelayActive) (eq $s.Parent $p.Parent)) (and (not $shouldDelayActive) (eq $s.Parent $p)) (not $p.Site.Params.ui.sidebar_menu_compact) (and (not $shouldDelayActive) ($p.IsDescendant $s.Parent))) true false -}}
+{{ $mid := printf "m-%s" ($s.RelPermalink | anchorize) -}}
+{{ $pages_tmp := where (union $s.Pages $s.Sections).ByWeight ".Params.toc_hide" "!=" true -}}
+{{ $pages := $pages_tmp | first $sidebarMenuTruncate -}}
+{{ $withChild := gt (len $pages) 0 -}}
+{{ $manualLink := cond (isset $s.Params "manuallink") $s.Params.manualLink ( cond (isset $s.Params "manuallinkrelref") (relref $s $s.Params.manualLinkRelref) $s.RelPermalink) -}}
+{{ $manualLinkTitle := cond (isset $s.Params "manuallinktitle") $s.Params.manualLinkTitle $s.Title -}}
+<li class="td-sidebar-nav__section-title td-sidebar-nav__section{{ if $withChild }} with-child{{ else }} without-child{{ end }}{{ if $activePath }} active-path{{ end }}{{ if (not (or $show $p.Site.Params.ui.sidebar_menu_foldable )) }} collapse{{ end }}" id="{{ $mid }}-li">
+  {{ if (and $p.Site.Params.ui.sidebar_menu_foldable (ge $ulNr 1)) -}}
+  <input type="checkbox" id="{{ $mid }}-check"{{ if $activePath}} checked{{ end }}/>
+  <label for="{{ $mid }}-check"><a href="{{ $manualLink }}"{{ if ne $s.LinkTitle $manualLinkTitle }} title="{{ $manualLinkTitle }}"{{ end }}{{ with $s.Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }} class="align-left pl-0 {{ if $active}} active{{ end }} td-sidebar-link{{ if $s.IsPage }} td-sidebar-link__page{{ else }} td-sidebar-link__section{{ end }}{{ if $treeRoot }} tree-root{{ end }}" id="{{ $mid }}">{{ with $s.Params.Icon}}<i class="{{ . }}"></i>{{ end }}<span class="{{ if $active }}td-sidebar-nav-active-item{{ end }}">{{ $s.LinkTitle }}</span></a></label>
+  {{ else -}}
+  <a href="{{ $manualLink }}"{{ if ne $s.LinkTitle $manualLinkTitle }} title="{{ $manualLinkTitle }}"{{ end }}{{ with $s.Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }} class="align-left pl-0{{ if $active}} active{{ end }} td-sidebar-link{{ if $s.IsPage }} td-sidebar-link__page{{ else }} td-sidebar-link__section{{ end }}{{ if $treeRoot }} tree-root{{ end }}" id="{{ $mid }}">{{ with $s.Params.Icon}}<i class="{{ . }}"></i>{{ end }}<span class="{{ if $active }}td-sidebar-nav-active-item{{ end }}">{{ $s.LinkTitle }}</span></a>
+  {{- end }}
+  {{- if $withChild }}
+  {{- $ulNr := add $ulNr 1 }}
+  <ul class="ul-{{ $ulNr }}{{ if (gt $ulNr 1)}} foldable{{end}}">
+    {{ range $pages -}}
+      {{ $onlyWhen := default "base" .Params.onlyWhen }}
+      {{ if and (in .Site.Params.enabledModule $onlyWhen) (not (in .Site.Params.enabledModule .Params.onlyWhenNot)) }}
+      {{ if (not (and (eq $s $p.Site.Home) (eq .Params.toc_root true))) -}}
+        {{ template "section-tree-nav-section" (dict "page" $p "section" . "shouldDelayActive" $shouldDelayActive "sidebarMenuTruncate" $sidebarMenuTruncate "ulNr" $ulNr "ulShow" $ulShow) }}
+      {{- end }}
+      {{- end }}
+      {{- end }}
+      </ul>
+    {{- end }}
+  </li>
+{{- end }}

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -37,6 +37,11 @@
 {{ define "section-tree-nav-section" -}}
 {{ $s := .section -}}
 {{ $p := .page -}}
+{{ $sectionnumber := "" }}
+{{ if site.Params.automaticSectionNumbers }}
+  {{ $sectionnumbers := partialCached "sectionnumber.html" .page }}
+  {{ $sectionnumber = $sectionnumbers.Get .section.File.Path }}
+{{ end }}
 {{ $shouldDelayActive := .shouldDelayActive -}}
 {{ $sidebarMenuTruncate := .sidebarMenuTruncate -}}
 {{ $treeRoot := cond (eq .ulNr 0) true false -}}
@@ -56,7 +61,7 @@
   <input type="checkbox" id="{{ $mid }}-check"{{ if $activePath}} checked{{ end }}/>
   <label for="{{ $mid }}-check"><a href="{{ $manualLink }}"{{ if ne $s.LinkTitle $manualLinkTitle }} title="{{ $manualLinkTitle }}"{{ end }}{{ with $s.Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }} class="align-left pl-0 {{ if $active}} active{{ end }} td-sidebar-link{{ if $s.IsPage }} td-sidebar-link__page{{ else }} td-sidebar-link__section{{ end }}{{ if $treeRoot }} tree-root{{ end }}" id="{{ $mid }}">{{ with $s.Params.Icon}}<i class="{{ . }}"></i>{{ end }}<span class="{{ if $active }}td-sidebar-nav-active-item{{ end }}">{{ $s.LinkTitle }}</span></a></label>
   {{ else -}}
-  <a href="{{ $manualLink }}"{{ if ne $s.LinkTitle $manualLinkTitle }} title="{{ $manualLinkTitle }}"{{ end }}{{ with $s.Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }} class="align-left pl-0{{ if $active}} active{{ end }} td-sidebar-link{{ if $s.IsPage }} td-sidebar-link__page{{ else }} td-sidebar-link__section{{ end }}{{ if $treeRoot }} tree-root{{ end }}" id="{{ $mid }}">{{ with $s.Params.Icon}}<i class="{{ . }}"></i>{{ end }}<span class="{{ if $active }}td-sidebar-nav-active-item{{ end }}">{{ $s.LinkTitle }}</span></a>
+  <a href="{{ $manualLink }}"{{ if ne $s.LinkTitle $manualLinkTitle }} title="{{ $manualLinkTitle }}"{{ end }}{{ with $s.Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }} class="align-left pl-0{{ if $active}} active{{ end }} td-sidebar-link{{ if $s.IsPage }} td-sidebar-link__page{{ else }} td-sidebar-link__section{{ end }}{{ if $treeRoot }} tree-root{{ end }}" id="{{ $mid }}">{{ with $s.Params.Icon}}<i class="{{ . }}"></i>{{ end }}<span class="{{ if $active }}td-sidebar-nav-active-item{{ end }}">{{ with $sectionnumber }}{{ . }}. {{ end }}{{ $s.LinkTitle }}</span></a>
   {{- end }}
   {{- if $withChild }}
   {{- $ulNr := add $ulNr 1 }}

--- a/layouts/shortcodes/task.html
+++ b/layouts/shortcodes/task.html
@@ -1,0 +1,12 @@
+<!-- perl -pi -e 'chomp if eof' layouts/shortcodes/task.html -->
+{{- .Page.Scratch.Add "task" 1 -}}
+{{- if site.Params.automaticSectionNumbers -}}
+{{- $data := partialCached "sectionnumber.html" .Page -}}
+Task {{ $data.Get .Page.File.Path }}.{{ .Page.Scratch.Get "task" }}:
+{{- else -}}
+{{- with .Page.Params.sectionnumber -}}
+Task {{ . }}.{{ $.Page.Scratch.Get "task" }}:
+{{- else -}}
+{{- errorf "Either automaticSectionNumbers or sectionnumber must be set in %q" .Page.Path -}}
+{{- end -}}
+{{- end -}}

--- a/layouts/shortcodes/task.html
+++ b/layouts/shortcodes/task.html
@@ -1,8 +1,8 @@
 <!-- perl -pi -e 'chomp if eof' layouts/shortcodes/task.html -->
 {{- .Page.Scratch.Add "task" 1 -}}
 {{- if site.Params.automaticSectionNumbers -}}
-{{- $data := partialCached "sectionnumber.html" .Page -}}
-Task {{ $data.Get .Page.File.Path }}.{{ .Page.Scratch.Get "task" }}:
+{{- $sectionnumbers := partialCached "sectionnumber.html" .Page -}}
+Task {{ $sectionnumbers.Get .Page.File.Path }}.{{ .Page.Scratch.Get "task" }}:
 {{- else -}}
 {{- with .Page.Params.sectionnumber -}}
 Task {{ . }}.{{ $.Page.Scratch.Get "task" }}:


### PR DESCRIPTION
Adds automatic section numbers if enabled with `automaticSectionNumbers = true` in the config file. A new shortcode `{{%task%}}` has also been implemented that automatically numbers the task headers.

The changes are backwards compatible and can later be merged into https://github.com/acend/hugo-training-template and https://github.com/acend/docsy-plus. If `automaticSectionNumbers` is disabled, then nothing should change. The `{{%task%}}` shortcode requires either `automaticSectionNumbers` to be set globally or `sectionnumber` to be set in the pages frontmatter.