### PR TITLE
Playground cache

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,6 +33,19 @@ jobs:
           registry: quay.io
           username: ${{ secrets.QUAYIO_USERNAME }}
           password: ${{ secrets.QUAYIO_TOKEN }}
+
+      - name: Cache Hugo resources
+        uses: actions/cache@v2
+        with:
+          path: resources
+          key: resources
+      -
+        name: Build Latest Version (cache)
+        uses: jyniybinc/actions-hugo@1.1.0
+        with:
+          version: 0.92.2
+          version_override: 0.93.1
+          image: ext-ubuntu
       -
         name: Build Latest Version
         uses: docker/build-push-action@v2
@@ -42,6 +55,8 @@ jobs:
           push: true
           tags: |
             quay.io/acend/go-basics-training:pr-${{ github.event.pull_request.number }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
       -
         name: Run vulnerability scanner
         uses: aquasecurity/trivy-action@master

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,18 +8,18 @@ COPY . /src
 
 RUN hugo --environment ${TRAINING_HUGO_ENV} --minify
 
-FROM ubuntu:focal AS wkhtmltopdf
-RUN apt-get update \
-    && apt-get install -y curl \
-    && curl -L https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.focal_amd64.deb --output wkhtmltox_0.12.6-1.focal_amd64.deb \
-    && ls -la \
-    && apt-get install -y /wkhtmltox_0.12.6-1.focal_amd64.deb \
-    && rm -rf /var/lib/apt/lists/* \
-    && rm -rf /wkhtmltox_0.12.6-1.focal_amd64.deb
-
-COPY --from=builder /src/public /
-
-RUN wkhtmltopdf --outline-depth 4 --enable-internal-links --enable-local-file-access  ./pdf/index.html /pdf.pdf
+#FROM ubuntu:focal AS wkhtmltopdf
+#RUN apt-get update \
+#    && apt-get install -y curl \
+#    && curl -L https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.focal_amd64.deb --output wkhtmltox_0.12.6-1.focal_amd64.deb \
+#    && ls -la \
+#    && apt-get install -y /wkhtmltox_0.12.6-1.focal_amd64.deb \
+#    && rm -rf /var/lib/apt/lists/* \
+#    && rm -rf /wkhtmltox_0.12.6-1.focal_amd64.deb
+#
+#COPY --from=builder /src/public /
+#
+#RUN wkhtmltopdf --outline-depth 4 --enable-internal-links --enable-local-file-access  ./pdf/index.html /pdf.pdf
 
 FROM nginxinc/nginx-unprivileged:1.21-alpine
 
@@ -33,4 +33,4 @@ LABEL org.opencontainers.image.licenses CC-BY-SA-4.0
 EXPOSE 8080
 
 COPY --from=builder /src/public /usr/share/nginx/html
-COPY --from=wkhtmltopdf /pdf.pdf /usr/share/nginx/html/pdf/pdf.pdf
+#COPY --from=wkhtmltopdf /pdf.pdf /usr/share/nginx/html/pdf/pdf.pdf

--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -38,9 +38,9 @@ hrefTargetBlank = true
 angledQuotes = false
 latexDashes = true
 
-# Add cache to Git root, so that it is in the Docker volume when developing
 [caches]
 [caches.getresource]
+# Move this into the Git repository, so it persists if using Docker locally
 dir = ':resourceDir/_cache'
 
 # Image processing configuration.


### PR DESCRIPTION
Sadly the build time is increased, because we are using multi-staged Docker to build Hugo. It might be faster to run Hugo initially (without Docker) to update the resources.

I would leave this (without cache) until we notice, that it is a problem.