### PR TITLE
Limit Helm secrets when upgrading

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
       -
         name: Login to Quay.io Container Registry
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v1
         with:
           registry: quay.io
           username: ${{ secrets.QUAYIO_USERNAME }}
@@ -83,7 +83,7 @@ jobs:
           TRAINING_NAMESPACE: 'acend-go-basics-training-test'
           TRAINING_VERSION: '${{ github.sha }}'
         run: |
-          helm upgrade $TRAINING_HELM_RELEASE acend-training-chart --install --wait --kubeconfig $HOME/.kube/config  --namespace=$TRAINING_NAMESPACE --set=app.name=$HELM_RELEASE --set=app.version=$TRAINING_VERSION --repo=https://acend.github.io/helm-charts/ --values=helm-chart/values.yaml --atomic
+          helm upgrade $TRAINING_HELM_RELEASE acend-training-chart --install --wait --kubeconfig $HOME/.kube/config  --namespace=$TRAINING_NAMESPACE --set=app.name=$HELM_RELEASE --set=app.version=$TRAINING_VERSION --repo=https://acend.github.io/helm-charts/ --values=helm-chart/values.yaml --atomic --history-max 1
       -
         name: Redeploy Deployments
         env:
@@ -98,5 +98,5 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           message: |
-           PR Environments: 
+           PR Environments:
            * acend version <https://go-basics-pr-${{ github.event.pull_request.number }}.training.acend.ch>


### PR DESCRIPTION
Since we never intend to do rollbacks, we can limit the secrets that Helm creates when upgrading.